### PR TITLE
Implement `check-sat-assuming`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -201,13 +201,11 @@ impl Context {
             .solver
             .as_mut()
             .expect("check requires a running solver");
-        let arg = self.arena.list(
-            Some(self.atoms.check_sat_assuming)
-                .into_iter()
-                .chain(props.into_iter())
-                .collect(),
-        );
-        solver.send(&self.arena, arg)?;
+        let args = self.arena.list(props.into_iter().collect());
+        solver.send(
+            &self.arena,
+            self.arena.list(vec![self.atoms.check_sat_assuming, args]),
+        )?;
         let resp = solver.recv(&self.arena)?;
         if resp == self.atoms.sat {
             Ok(Response::Sat)

--- a/src/context.rs
+++ b/src/context.rs
@@ -192,6 +192,7 @@ impl Context {
         )
     }
 
+    /// Assert `check-sat` for the current context.
     pub fn check(&mut self) -> io::Result<Response> {
         let solver = self
             .solver
@@ -213,6 +214,7 @@ impl Context {
         }
     }
 
+    /// Declare a new constant with the provided sort
     pub fn declare_const<S: Into<String> + AsRef<str>>(
         &mut self,
         name: S,
@@ -277,19 +279,23 @@ impl Context {
         )
     }
 
+    /// Declares a unit value of the given sort
     pub fn declare<S: Into<String> + AsRef<str>>(
         &mut self,
         name: S,
-        body: SExpr,
+        sort: SExpr,
     ) -> io::Result<SExpr> {
-        self.declare_fun(name, vec![], body)
+        // TODO(rachit): This is exactly what SMTLIB's declare-const does. We
+        // should either remove this or [Self::declare_const].
+        self.declare_fun(name, vec![], sort)
     }
 
+    /// Declares a new, uninterpreted function symbol.
     pub fn declare_fun<S: Into<String> + AsRef<str>>(
         &mut self,
         name: S,
         args: Vec<SExpr>,
-        body: SExpr,
+        out: SExpr,
     ) -> io::Result<SExpr> {
         let name = self.atom(name);
         let solver = self
@@ -303,10 +309,53 @@ impl Context {
                 self.atoms.declare_fun,
                 name,
                 self.arena.list(args),
+                out,
+            ]),
+        )?;
+        Ok(name)
+    }
+
+    /// Defines a new function with a body.
+    pub fn define_fun<S: Into<String> + AsRef<str>>(
+        &mut self,
+        name: S,
+        args: Vec<(S, SExpr)>,
+        out: SExpr,
+        body: SExpr,
+    ) -> io::Result<SExpr> {
+        let name = self.atom(name);
+        let args = args
+            .into_iter()
+            .map(|(n, s)| self.list(vec![self.atom(n), s]))
+            .collect();
+        let solver = self
+            .solver
+            .as_mut()
+            .expect("define_fun requires a running solver");
+        solver.ack_command(
+            &self.arena,
+            self.atoms.success,
+            self.arena.list(vec![
+                self.atoms.define_fun,
+                name,
+                self.arena.list(args),
+                out,
                 body,
             ]),
         )?;
         Ok(name)
+    }
+
+    /// Define a constant with a body with a value.
+    /// This is a convenience wrapper over [Self::define_fun] since constants
+    /// are nullary functions.
+    pub fn define_const<S: Into<String> + AsRef<str>>(
+        &mut self,
+        name: S,
+        out: SExpr,
+        body: SExpr,
+    ) -> io::Result<SExpr> {
+        self.define_fun(name, vec![], out, body)
     }
 
     pub fn declare_sort<S: Into<String> + AsRef<str>>(
@@ -341,6 +390,7 @@ impl Context {
         )
     }
 
+    /// Get a model out from the solver. This is only meaningful after a `check-sat` query.
     pub fn get_model(&mut self) -> io::Result<SExpr> {
         let solver = self
             .solver
@@ -350,6 +400,7 @@ impl Context {
         solver.recv(&self.arena)
     }
 
+    /// Get bindings for values in the model. This is only meaningful after a `check-sat` query.
     pub fn get_value(&mut self, vals: Vec<SExpr>) -> io::Result<Vec<(SExpr, SExpr)>> {
         let solver = self
             .solver
@@ -410,6 +461,7 @@ impl Context {
         )
     }
 
+    /// Push a new context frame in the solver. Same as SMTLIB's `push` command.
     pub fn push(&mut self) -> io::Result<()> {
         let solver = self
             .solver
@@ -435,6 +487,7 @@ impl Context {
         )
     }
 
+    /// Pop a context frame in the solver. Same as SMTLIB's `pop` command.
     pub fn pop(&mut self) -> io::Result<()> {
         let solver = self.solver.as_mut().expect("pop requires a running solver");
         solver.ack_command(

--- a/src/context.rs
+++ b/src/context.rs
@@ -279,14 +279,12 @@ impl Context {
         )
     }
 
-    /// Declares a unit value of the given sort
+    /// Declares an unconstrained value of the given sort
     pub fn declare<S: Into<String> + AsRef<str>>(
         &mut self,
         name: S,
         sort: SExpr,
     ) -> io::Result<SExpr> {
-        // TODO(rachit): This is exactly what SMTLIB's declare-const does. We
-        // should either remove this or [Self::declare_const].
         self.declare_fun(name, vec![], sort)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -665,6 +665,9 @@ impl Context {
     left_assoc!(sub, sub_many, minus);
     left_assoc!(plus, plus_many, plus);
     left_assoc!(times, times_many, times);
+    left_assoc!(div, div_many, div);
+    left_assoc!(modulo, modulo_many, modulo);
+    left_assoc!(rem, rem_many, rem);
     chainable!(lte, lte_many, lte);
     chainable!(lt, lt_many, lt);
     chainable!(gt, gt_many, gt);

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -13,6 +13,7 @@ macro_rules! for_each_known_atom {
             par: "par";
             declare_sort: "declare-sort";
             declare_fun: "declare-fun";
+            define_fun: "define-fun";
             assert: "assert";
             get_model: "get-model";
             get_value: "get-value";

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -3,7 +3,7 @@ use crate::{sexpr::Arena, SExpr};
 macro_rules! for_each_known_atom {
     ( $mac:ident ) => {
         $mac! {
-            check_sat: "check-sat";
+            check_sat_assuming: "check-sat-assuming";
             unsat: "unsat";
             sat: "sat";
             unknown: "unknown";

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -38,6 +38,9 @@ macro_rules! for_each_known_atom {
             minus: "-";
             plus: "+";
             times: "*";
+            div: "div";
+            modulo: "mod";
+            rem: "rem";
             lte: "<=";
             lt: "<";
             gte: ">=";

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -3,6 +3,7 @@ use crate::{sexpr::Arena, SExpr};
 macro_rules! for_each_known_atom {
     ( $mac:ident ) => {
         $mac! {
+            check_sat: "check-sat";
             check_sat_assuming: "check-sat-assuming";
             unsat: "unsat";
             sat: "sat";


### PR DESCRIPTION
Implements `check-sat-assuming` and reimplements `check-sat` as a special case of that. The former is useful because often times it lets you get away with not having to use `push` and `pop` (and in fact needed to implement #20).