### PR TITLE
Bump to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "easy-smt"
-version = "0.1.2"
+version = "0.2.0"
 authors = [
     "Trevor Elliott <awesomelyawesome@gmail.com>",
     "Nick Fitzgerald <fitzgen@gmail.com>",


### PR DESCRIPTION
Bump to `0.2.0` as we will be removing the `declare` method in this release.
