### PR TITLE
Implement `(exit)` command

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -483,6 +483,19 @@ impl Context {
         )
     }
 
+    /// Instruct the solver to exit.
+    pub fn exit(&mut self) -> io::Result<()> {
+        let solver = self
+            .solver
+            .as_mut()
+            .expect("exit requires a running solver");
+        solver.ack_command(
+            &self.arena,
+            self.atoms.success,
+            self.arena.list(vec![self.atoms.exit]),
+        )
+    }
+
     /// Push a new context frame in the solver. Same as SMTLIB's `push` command.
     pub fn push(&mut self) -> io::Result<()> {
         let solver = self

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -21,6 +21,7 @@ macro_rules! for_each_known_atom {
             get_unsat_core: "get-unsat-core";
             set_logic: "set-logic";
             set_option: "set-option";
+            exit: "exit";
             push: "push";
             pop: "pop";
             bool: "Bool";


### PR DESCRIPTION
Implement the `(exit)` command.

This helps to support graceful solver exit, which is especially important for clients which create many `easy-smt` contexts.

The `(exit)` command is specified in SMT-LIB 2.6 section 4.2.1 "(Re)starting and terminating".