### PR TITLE
Wait for solver process on drop

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -74,6 +74,7 @@ impl Solver {
 
 impl Drop for Solver {
     fn drop(&mut self) {
+        let _ = self.handle.kill();
         let _ = self.handle.wait();
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -4,7 +4,7 @@ use std::io::{self, BufRead};
 use std::process;
 
 pub(crate) struct Solver {
-    _handle: process::Child,
+    handle: process::Child,
     stdin: process::ChildStdin,
     stdout: io::Lines<io::BufReader<process::ChildStdout>>,
     replay_file: Box<dyn io::Write + Send>,
@@ -26,7 +26,7 @@ impl Solver {
         let stdout = handle.stdout.take().unwrap();
 
         Ok(Self {
-            _handle: handle,
+            handle,
             stdin,
             stdout: io::BufReader::new(stdout).lines(),
             replay_file,
@@ -69,5 +69,11 @@ impl Solver {
                 format!("Unexpected result from solver: {}", arena.display(resp)),
             ))
         }
+    }
+}
+
+impl Drop for Solver {
+    fn drop(&mut self) {
+        let _ = self.handle.wait();
     }
 }


### PR DESCRIPTION
Wait for the child process when `Solver` is dropped.

Rust `std::process::Child` does not kill on drop. Without waiting on the solver process, a program that spins up many `easy-smt` contexts can leave zombie solver child processes.
