### PR TITLE
allow `Context` to be `Send`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -71,7 +71,7 @@ macro_rules! pairwise {
 #[derive(Default)]
 pub struct ContextBuilder {
     solver_program_and_args: Option<(ffi::OsString, Vec<ffi::OsString>)>,
-    replay_file: Option<Box<dyn io::Write>>,
+    replay_file: Option<Box<dyn io::Write + Send>>,
 }
 
 impl ContextBuilder {
@@ -117,7 +117,7 @@ impl ContextBuilder {
     /// By default, there is no replay file configured.
     pub fn replay_file<W>(&mut self, replay_file: Option<W>) -> &mut Self
     where
-        W: 'static + io::Write,
+        W: 'static + io::Write + Send,
     {
         self.replay_file = replay_file.map(|w| Box::new(w) as _);
         self

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -7,7 +7,7 @@ pub(crate) struct Solver {
     _handle: process::Child,
     stdin: process::ChildStdin,
     stdout: io::Lines<io::BufReader<process::ChildStdout>>,
-    replay_file: Box<dyn io::Write>,
+    replay_file: Box<dyn io::Write + Send>,
     parser: Parser,
 }
 
@@ -15,7 +15,7 @@ impl Solver {
     pub fn new(
         program: ffi::OsString,
         args: Vec<ffi::OsString>,
-        replay_file: Box<dyn io::Write>,
+        replay_file: Box<dyn io::Write + Send>,
     ) -> io::Result<Self> {
         let mut handle = process::Command::new(program)
             .args(args)


### PR DESCRIPTION
I am trying to use a single solver across multiple threads. That requires `Context` to implement `Send`. The only thing I had to change was to require the `replay_file` to be `Send` which should be fine since `std::fs::File` implements `Send`: https://doc.rust-lang.org/std/fs/struct.File.html#impl-Send-for-File