### PR TITLE
Add support for `bvsdiv` and `bvsmod` functions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -866,6 +866,7 @@ impl Context {
     binop!(bvurem, bvurem);
     binop!(bvsdiv, bvsdiv);
     binop!(bvsrem, bvsrem);
+    binop!(bvsmod, bvsmod);
     binop!(bvshl, bvshl);
     binop!(bvlshr, bvlshr);
     binop!(bvashr, bvashr);

--- a/src/context.rs
+++ b/src/context.rs
@@ -864,6 +864,7 @@ impl Context {
     left_assoc!(bvmul, bvmul_many, bvmul);
     binop!(bvudiv, bvudiv);
     binop!(bvurem, bvurem);
+    binop!(bvsdiv, bvsdiv);
     binop!(bvsrem, bvsrem);
     binop!(bvshl, bvshl);
     binop!(bvlshr, bvlshr);

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -71,6 +71,7 @@ macro_rules! for_each_known_atom {
             bvmul: "bvmul";
             bvudiv: "bvudiv";
             bvurem: "bvurem";
+            bvsdiv: "bvsdiv";
             bvsrem: "bvsrem";
             bvshl: "bvshl";
             bvlshr: "bvlshr";

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -72,6 +72,7 @@ macro_rules! for_each_known_atom {
             bvudiv: "bvudiv";
             bvurem: "bvurem";
             bvsdiv: "bvsdiv";
+            bvsmod: "bvsmod";
             bvsrem: "bvsrem";
             bvshl: "bvshl";
             bvlshr: "bvlshr";


### PR DESCRIPTION
Thanks for this library--I like the overall approach and will probably be using it quite a bit!

It looks like you've missed the definition for `bvsdiv`. From SMT-LIB QF_BV docs:

```
    (bvsdiv s t) abbreviates
      (let ((?msb_s ((_ extract |m-1| |m-1|) s))
            (?msb_t ((_ extract |m-1| |m-1|) t)))
        (ite (and (= ?msb_s #b0) (= ?msb_t #b0))
             (bvudiv s t)
        (ite (and (= ?msb_s #b1) (= ?msb_t #b0))
             (bvneg (bvudiv (bvneg s) t))
        (ite (and (= ?msb_s #b0) (= ?msb_t #b1))
             (bvneg (bvudiv s (bvneg t)))
             (bvudiv (bvneg s) (bvneg t))))))
    (bvsmod s t) abbreviates
      (let ((?msb_s ((_ extract |m-1| |m-1|) s))
            (?msb_t ((_ extract |m-1| |m-1|) t)))
        (let ((abs_s (ite (= ?msb_s #b0) s (bvneg s)))
              (abs_t (ite (= ?msb_t #b0) t (bvneg t))))
          (let ((u (bvurem abs_s abs_t)))
            (ite (= u (_ bv0 m))
                 u
            (ite (and (= ?msb_s #b0) (= ?msb_t #b0))
                 u
            (ite (and (= ?msb_s #b1) (= ?msb_t #b0))
                 (bvadd (bvneg u) t)
            (ite (and (= ?msb_s #b0) (= ?msb_t #b1))
                 (bvadd u t)
                 (bvneg u))))))))
```