### PR TITLE
Support parsing multiple lines

### DIFF
--- a/src/solver.rs
+++ b/src/solver.rs
@@ -1,4 +1,4 @@
-use crate::sexpr::{Arena, Parser, SExpr};
+use crate::sexpr::{Arena, ParseError, Parser, SExpr};
 use std::ffi;
 use std::io::{self, BufRead};
 use std::process;
@@ -49,11 +49,10 @@ impl Solver {
             log::trace!("<- {}", line);
             match self.parser.parse(arena, &line) {
                 Ok(res) => return Ok(res),
-                Err(msg) => {
+                Err(ParseError::More) => continue,
+                Err(ParseError::Message(msg)) => {
                     log::error!("Failed to parse: {line}");
-                    if let Some(msg) = msg {
-                        log::error!("Parse error: {msg}");
-                    }
+                    log::error!("Parse error: {msg}");
                 }
             }
         }


### PR DESCRIPTION
Fixes #40

Call the parser until either an error occurs, or the s-expression is parsed successfully. I think the downside here is that a list parsing error in the message from the solver could put the parser into a state where it's parsing forever, but I'm not sure that we can really detect that case without any other framing.
