### PR TITLE
Add support for parsing negative solution values

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -659,6 +659,186 @@ impl Context {
         self.arena.get(expr)
     }
 
+    /// Get the atom data for the given s-expression.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// atom this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_atom(&self, expr: SExpr) -> Option<&str> {
+        self.arena.get_atom(expr)
+    }
+
+    /// Get the string data for the given s-expression.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// string this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_str(&self, expr: SExpr) -> Option<&str> {
+        self.arena.get_str(expr)
+    }
+
+    /// Get the list data for the given s-expression.
+    ///
+    /// This allows you to inspect s-expressions.If the s-expression is not an
+    /// list this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_list(&self, expr: SExpr) -> Option<&[SExpr]> {
+        self.arena.get_list(expr)
+    }
+
+    /// Get the data for the given s-expression as an `u8`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `u8` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_u8(&self, expr: SExpr) -> Option<u8> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `u16`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `u16` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_u16(&self, expr: SExpr) -> Option<u16> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `u32`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `u32` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_u32(&self, expr: SExpr) -> Option<u32> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `u64`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `u64` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_u64(&self, expr: SExpr) -> Option<u64> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `u128`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `u128` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_u128(&self, expr: SExpr) -> Option<u128> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `usize`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `usize` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_usize(&self, expr: SExpr) -> Option<usize> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `i8`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `i8` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_i8(&self, expr: SExpr) -> Option<i8> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `i16`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `i16` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_i16(&self, expr: SExpr) -> Option<i16> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `i32`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `i32` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_i32(&self, expr: SExpr) -> Option<i32> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `i64`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `i64` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_i64(&self, expr: SExpr) -> Option<i64> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `i128`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `i128` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_i128(&self, expr: SExpr) -> Option<i128> {
+        self.arena.get_t(expr)
+    }
+
+    /// Get the data for the given s-expression as an `isize`.
+    ///
+    /// This allows you to inspect s-expressions. If the s-expression is not an
+    /// cannot be parsed into an `isize` this function returns `None`.
+    ///
+    /// You may only pass in `SExpr`s that were created by this
+    /// `Context`. Failure to do so is safe, but may trigger a panic or return
+    /// invalid data.
+    pub fn get_isize(&self, expr: SExpr) -> Option<isize> {
+        self.arena.get_t(expr)
+    }
+
     /// Access "known" atoms.
     ///
     /// This lets you skip the is-it-already-interned-or-not checks and hash map

--- a/src/sexpr.rs
+++ b/src/sexpr.rs
@@ -265,7 +265,11 @@ impl Arena {
                 return None;
             }
 
-            let is_negated = inner.strings[data[0].index()].as_str() == "-";
+            let is_negated = match inner.strings[data[0].index()].as_str() {
+                "-" => true,
+                "+" => false,
+                _ => return None,
+            };
 
             let r_data = inner.strings[data[1].index()].as_str();
 

--- a/src/sexpr.rs
+++ b/src/sexpr.rs
@@ -196,34 +196,17 @@ impl Arena {
 
         if expr.is_atom() {
             // Safety argument: the data will live as long as the containing context, and is
-            // immutable once it's inserted, so using the lifetime of the Arena is acceptable.
+            // immutable once it's inserted, so using the lifteime of the Arena is acceptable.
             let data = unsafe { std::mem::transmute(inner.strings[expr.index()].as_str()) };
             SExprData::Atom(data)
         } else if expr.is_list() {
             // Safety argument: the data will live as long as the containing context, and is
-            // immutable once it's inserted, so using the lifetime of the Arena is acceptable.
-            let data: &[SExpr] =
-                unsafe { std::mem::transmute(inner.lists[expr.index()].as_slice()) };
-
-            if data.len() == 2 && data.iter().all(|e| e.is_atom()) {
-                // Safety argument: the data will live as long as the containing context, and is
-                // immutable once it's inserted, so using the lifetime of the Arena is acceptable.
-                let l_data =
-                    unsafe { std::mem::transmute(inner.strings[data[0].index()].as_str()) };
-
-                if !"+-".contains(l_data) {
-                    return SExprData::List(data);
-                }
-
-                let r_data =
-                    unsafe { std::mem::transmute(inner.strings[data[1].index()].as_str()) };
-                return SExprData::TwoAtomList(l_data, r_data);
-            }
-
+            // immutable once it's inserted, so using the lifteime of the Arena is acceptable.
+            let data = unsafe { std::mem::transmute(inner.lists[expr.index()].as_slice()) };
             SExprData::List(data)
         } else if expr.is_string() {
             // Safety argument: the data will live as long as the containing context, and is
-            // immutable once it's inserted, so using the lifetime of the Arena is acceptable.
+            // immutable once it's inserted, so using the lifteime of the Arena is acceptable.
             let data = unsafe { std::mem::transmute(inner.strings[expr.index()].as_str()) };
             SExprData::String(data)
         } else {
@@ -253,7 +236,6 @@ pub enum SExprData<'a> {
     Atom(&'a str),
     String(&'a str),
     List(&'a [SExpr]),
-    TwoAtomList(&'a str, &'a str),
 }
 
 /// An error which can be returned when trying to interpret an s-expr as an
@@ -278,7 +260,7 @@ impl std::fmt::Display for IntFromSExprError {
                  therefore cannot be converted to an integer."
             ),
             IntFromSExprError::ParseIntError(_) => {
-                write!(f, "There was an error parsing the atom as an integer.")
+                write!(f, "There wasn an error parsing the atom as an integer.")
             }
         }
     }
@@ -321,13 +303,7 @@ macro_rules! impl_try_from_int {
                             let x = a.parse::<$ty>()?;
                             Ok(x)
                         }
-                        SExprData::TwoAtomList(l, r) => {
-                            let j = l.to_owned() + r;
-                            let x = j.parse::<$ty>()?;
-                            Ok(x)
-                        },
-                        SExprData::List(_) |
-                        SExprData::String(_)  => Err(IntFromSExprError::NotAnAtom),
+                        SExprData::String(_) | SExprData::List(_) => Err(IntFromSExprError::NotAnAtom),
                     }
                 }
             }
@@ -335,7 +311,7 @@ macro_rules! impl_try_from_int {
     };
 }
 
-impl_try_from_int!(u8 u16 u32 u64 u128 usize i8 i16 i32 i64);
+impl_try_from_int!(u8 u16 u32 u64 u128 usize);
 
 pub struct DisplayExpr<'a> {
     arena: &'a Arena,
@@ -350,13 +326,6 @@ impl<'a> std::fmt::Display for DisplayExpr<'a> {
             match arena.get(sexpr) {
                 SExprData::Atom(data) => std::fmt::Display::fmt(data, f),
                 SExprData::String(data) => std::fmt::Debug::fmt(data, f),
-                SExprData::TwoAtomList(l_data, r_data) => {
-                    write!(f, "(")?;
-                    std::fmt::Display::fmt(l_data, f)?;
-                    write!(f, " ")?;
-                    std::fmt::Display::fmt(r_data, f)?;
-                    write!(f, ")")
-                }
                 SExprData::List(data) => {
                     write!(f, "(")?;
                     let mut sep = "";
@@ -683,8 +652,7 @@ mod tests {
             .expect_err("Single atom doesn't close a list")
             .expect_more();
 
-        let expr = p
-            .parse(&arena, ")")
+        let expr = p.parse(&arena, ")")
             .expect("Closing paren should finish the parse");
 
         let SExprData::List(es) = arena.get(expr) else {


### PR DESCRIPTION
## Description

This PR would add support for solutions that contain negative integers. 

Currently, the problem with negative solutions is that the SMT solver will return for example `(x (- 2))`  a solution to `x < 0` . When calling `get`, this solution will be parsed into an `SExprData::List` . Calling `try_from_int` will then return always return the error `NotAnAtom`.

This PR introduces a new variant of `SExprData`, which is a special case of `SExprData::List`, which is returned for lists that  contain exactly two atoms , where the first one is either `+` or `-`. 

Additionally it fixes typos in comments.


## Minimal Test

```rust
use easy_smt::{ContextBuilder, Response};

#[test]
fn test_negative_integers() {
    let mut ctx = ContextBuilder::new()
        .solver("z3")
        .solver_args(["-smt2", "-in"])
        .build()
        .unwrap();

    let x = ctx.declare_const("x", ctx.int_sort()).unwrap();

    ctx.assert(ctx.lt(x, ctx.numeral(0))).unwrap();

    assert_eq!(ctx.check().unwrap(), Response::Sat);

    let solution = ctx.get_value(vec![x]).unwrap();
    let sol_x = ctx.get(solution[0].1);

    let sol = i64::try_from(sol_x).expect("Failed to parse");
    assert!(sol < 0)
}
``` 