### PR TITLE
Defaults for well known SMT solvers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,26 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Install Z3
-      run: sudo apt install -y z3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run Sudoku Example
-      run: |
-        cargo run --example sudoku
-        cargo run --example quantifiers
+      - uses: actions/checkout@v3
+      - name: Install Z3
+        run: sudo apt install -y z3 cvc5
+      - name: Build
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Run Sudoku Example
+        run: |
+          cargo run --example sudoku
+          cargo run --example quantifiers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install Z3
+      - name: Install Solvers
         run: sudo apt install -y z3 cvc5
       - name: Build
         run: cargo build --verbose

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 `easy-smt` is a crate for interacting with an SMT solver subprocess. This crate
 provides APIs for
 
-* building up expressions and assertions using [the SMT-LIB 2
+- building up expressions and assertions using [the SMT-LIB 2
   language](https://smtlib.cs.uiowa.edu/),
-* querying an SMT solver for solutions to those assertions,
-* and inspecting the solver's results.
+- querying an SMT solver for solutions to those assertions,
+- and inspecting the solver's results.
 
 `easy-smt` works with any solver, as long as the solver has an interactive REPL
 mode. You just tell `easy-smt` how to spawn the subprocess.
@@ -33,8 +33,7 @@ use easy_smt::{ContextBuilder, Response};
 fn main() -> std::io::Result<()> {
     // Create a new context, backed by a Z3 subprocess.
     let mut ctx = ContextBuilder::new()
-        .solver("z3")
-        .solver_args(["-smt2", "-in"])
+        .with_z3_defaults()
         .build()?;
 
     // Declare `x` and `y` variables that are bitvectors of width 32.
@@ -148,8 +147,7 @@ fn main() -> std::io::Result<()> {
         // Everything needed to replay the solver session will be written
         // to `replay.smt2`.
         .replay_file(Some(std::fs::File::create("replay.smt2")?))
-        .solver("z3")
-        .solver_args(["-smt2", "-in"])
+        .with_z3_defaults()
         .build()?;
 
     // ...

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
 `easy-smt` is a crate for interacting with an SMT solver subprocess. This crate
 provides APIs for
 
-- building up expressions and assertions using [the SMT-LIB 2
+* building up expressions and assertions using [the SMT-LIB 2
   language](https://smtlib.cs.uiowa.edu/),
-- querying an SMT solver for solutions to those assertions,
-- and inspecting the solver's results.
+* querying an SMT solver for solutions to those assertions,
+* and inspecting the solver's results.
 
 `easy-smt` works with any solver, as long as the solver has an interactive REPL
 mode. You just tell `easy-smt` how to spawn the subprocess.

--- a/examples/quantifiers.rs
+++ b/examples/quantifiers.rs
@@ -3,10 +3,7 @@
 
 fn main() -> std::io::Result<()> {
     env_logger::init();
-    let mut ctx = easy_smt::ContextBuilder::new()
-        .solver("z3")
-        .solver_args(["-smt2", "-in"])
-        .build()?;
+    let mut ctx = easy_smt::ContextBuilder::new().with_z3_defaults().build()?;
 
     // Declare an uninterpreted representation for sets.
     ctx.declare_sort("MySet", 0)?;

--- a/examples/sudoku.rs
+++ b/examples/sudoku.rs
@@ -5,10 +5,7 @@ use easy_smt::SExpr;
 fn main() -> std::io::Result<()> {
     env_logger::init();
 
-    let mut ctx = easy_smt::ContextBuilder::new()
-        .solver("z3")
-        .solver_args(["-smt2", "-in"])
-        .build()?;
+    let mut ctx = easy_smt::ContextBuilder::new().with_z3_defaults().build()?;
 
     // for helping diagnose unsolvable problems
     ctx.set_option(":produce-unsat-cores", ctx.true_())?;

--- a/src/context.rs
+++ b/src/context.rs
@@ -68,6 +68,16 @@ macro_rules! pairwise {
     };
 }
 
+/// Command to start Z3
+pub const Z3_PRG: &str = "z3";
+/// Option to set Z3 in quiet mode, use SMT-LIB2 language
+pub const Z3_ARGS: [&str; 3] = ["-smt2", "-in", "-v:0"];
+
+/// Command to start CVC5
+pub const CVC5_PRG: &str = "cvc5";
+/// Option to set CVC5 in quiet mode, use SMT-LIB2 language
+pub const CVC5_ARGS: [&str; 3] = ["--quiet", "--lang=smt2", "--incremental"];
+
 #[derive(Default)]
 pub struct ContextBuilder {
     solver: Option<ffi::OsString>,
@@ -79,6 +89,16 @@ impl ContextBuilder {
     /// Construct a new builder with the default configuration.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Initialize the builder with Z3 defaults.
+    pub fn with_z3_defaults(&mut self) -> &mut Self {
+        self.solver(Z3_PRG).solver_args(Z3_ARGS)
+    }
+
+    /// Initialize the builder with CVC5 defaults.
+    pub fn with_cvc5_defaults(&mut self) -> &mut Self {
+        self.solver(CVC5_PRG).solver_args(CVC5_ARGS)
     }
 
     /// Configure the solver that will be used.

--- a/src/context.rs
+++ b/src/context.rs
@@ -68,16 +68,6 @@ macro_rules! pairwise {
     };
 }
 
-/// Command to start Z3
-pub const Z3_PRG: &str = "z3";
-/// Option to set Z3 in quiet mode, use SMT-LIB2 language
-pub const Z3_ARGS: [&str; 3] = ["-smt2", "-in", "-v:0"];
-
-/// Command to start CVC5
-pub const CVC5_PRG: &str = "cvc5";
-/// Option to set CVC5 in quiet mode, use SMT-LIB2 language
-pub const CVC5_ARGS: [&str; 3] = ["--quiet", "--lang=smt2", "--incremental"];
-
 #[derive(Default)]
 pub struct ContextBuilder {
     solver: Option<ffi::OsString>,
@@ -93,11 +83,21 @@ impl ContextBuilder {
 
     /// Initialize the builder with Z3 defaults.
     pub fn with_z3_defaults(&mut self) -> &mut Self {
+        // Command to start Z3
+        const Z3_PRG: &str = "z3";
+        // Option to set Z3 in quiet mode, use SMT-LIB2 language
+        const Z3_ARGS: [&str; 3] = ["-smt2", "-in", "-v:0"];
+
         self.solver(Z3_PRG).solver_args(Z3_ARGS)
     }
 
     /// Initialize the builder with CVC5 defaults.
     pub fn with_cvc5_defaults(&mut self) -> &mut Self {
+        // Command to start CVC5
+        const CVC5_PRG: &str = "cvc5";
+        // Option to set CVC5 in quiet mode, use SMT-LIB2 language
+        const CVC5_ARGS: [&str; 3] = ["--quiet", "--lang=smt2", "--incremental"];
+
         self.solver(CVC5_PRG).solver_args(CVC5_ARGS)
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -83,12 +83,7 @@ impl ContextBuilder {
 
     /// Initialize the builder with Z3 defaults.
     pub fn with_z3_defaults(&mut self) -> &mut Self {
-        // Command to start Z3
-        const Z3_PRG: &str = "z3";
-        // Option to set Z3 in quiet mode, use SMT-LIB2 language
-        const Z3_ARGS: [&str; 3] = ["-smt2", "-in", "-v:0"];
-
-        self.solver(Z3_PRG).solver_args(Z3_ARGS)
+        self.solver("z3").solver_args(["-smt2", "-in", "-v:0"])
     }
 
     /// Initialize the builder with CVC5 defaults.

--- a/src/context.rs
+++ b/src/context.rs
@@ -88,12 +88,7 @@ impl ContextBuilder {
 
     /// Initialize the builder with CVC5 defaults.
     pub fn with_cvc5_defaults(&mut self) -> &mut Self {
-        // Command to start CVC5
-        const CVC5_PRG: &str = "cvc5";
-        // Option to set CVC5 in quiet mode, use SMT-LIB2 language
-        const CVC5_ARGS: [&str; 3] = ["--quiet", "--lang=smt2", "--incremental"];
-
-        self.solver(CVC5_PRG).solver_args(CVC5_ARGS)
+        self.solver("cvc5").solver_args(["--quiet", "--lang=smt2", "--incremental"])
     }
 
     /// Configure the solver that will be used.

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -1,10 +1,7 @@
 // This test ensures that we can handle `(error "...")` responses from z3.
 #[test]
 fn handles_errors_gracefully() -> std::io::Result<()> {
-    let mut context = easy_smt::ContextBuilder::new()
-        .solver("z3")
-        .solver_args(["-smt2", "-in"])
-        .build()?;
+    let mut context = easy_smt::ContextBuilder::new().with_z3_defaults().build()?;
 
     let width = context.numeral(1);
     let sort = context.bit_vec_sort(width);

--- a/tests/solvers.rs
+++ b/tests/solvers.rs
@@ -1,0 +1,38 @@
+use easy_smt::{Context, Response};
+
+fn test_solver_interaction(solver: &mut Context) {
+    let int_sort = solver.int_sort();
+    let x = solver.declare_const("x", int_sort).unwrap();
+
+    // x <= 2 && x > 1
+    let constr = solver.and(
+        solver.lte(x, solver.numeral(2)),
+        solver.gt(x, solver.numeral(1)),
+    );
+    solver.assert(constr).unwrap();
+
+    assert_eq!(solver.check().unwrap(), Response::Sat);
+
+    let solution = solver.get_value(vec![x]).unwrap();
+    assert_eq!(solution.len(), 1);
+    assert_eq!(solution[0].0, x);
+    assert_eq!(solver.get_u64(solution[0].1).unwrap(), 2);
+}
+
+#[test]
+fn test_z3_solver() {
+    let mut context = easy_smt::ContextBuilder::new()
+        .with_z3_defaults()
+        .build()
+        .unwrap();
+    test_solver_interaction(&mut context);
+}
+
+#[test]
+fn test_cvc5_solver() {
+    let mut context = easy_smt::ContextBuilder::new()
+        .with_cvc5_defaults()
+        .build()
+        .unwrap();
+    test_solver_interaction(&mut context);
+}


### PR DESCRIPTION
This commit adds the methods `.with_z3_defaults()` and `.with_cvc5_defaults()` to the `ContextBuilder`. These methods will add the default arguments to start the respective SMT solver in REPL mode.