### PR TITLE
Add some more bitvector operations (rotations and extensions)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1091,12 +1091,61 @@ impl Context {
         ])
     }
 
+    /// Rotate the bits of a bit vector left by i bits.
+    pub fn rotate_left(&self, i: u32, bv: SExpr) -> SExpr {
+        self.list(vec![
+            self.list(vec![
+                self.atoms.und,
+                self.atoms.rotate_left,
+                self.numeral(i),
+            ]),
+            bv,
+        ])
+    }
+
+    /// Rotate the bits of a bit vector right by i bits.
+    pub fn rotate_right(&self, i: u32, bv: SExpr) -> SExpr {
+        self.list(vec![
+            self.list(vec![
+                self.atoms.und,
+                self.atoms.rotate_right,
+                self.numeral(i),
+            ]),
+            bv,
+        ])
+    }
+
+    /// Zero extend a bit vector by by_bits.
+    pub fn zero_extend(&self, by_bits: u32, bv: SExpr) -> SExpr {
+        self.list(vec![
+            self.list(vec![
+                self.atoms.und,
+                self.atoms.zero_extend,
+                self.numeral(by_bits),
+            ]),
+            bv,
+        ])
+    }
+
+    /// Sign extend a bit vector by by_bits.
+    pub fn sign_extend(&self, by_bits: u32, bv: SExpr) -> SExpr {
+        self.list(vec![
+            self.list(vec![
+                self.atoms.und,
+                self.atoms.sign_extend,
+                self.numeral(by_bits),
+            ]),
+            bv,
+        ])
+    }
+
     unary!(bvnot, bvnot);
     left_assoc!(bvor, bvor_many, bvor);
     left_assoc!(bvand, bvand_many, bvand);
     left_assoc!(bvnand, bvnand_many, bvnand);
     left_assoc!(bvxor, bvxor_many, bvxor);
     left_assoc!(bvxnor, bvxnor_many, bvxnor);
+    left_assoc!(bvnor, bvnor_many, bvnor);
     unary!(bvneg, bvneg);
     left_assoc!(bvadd, bvadd_many, bvadd);
     binop!(bvsub, bvsub);

--- a/src/known_atoms.rs
+++ b/src/known_atoms.rs
@@ -64,6 +64,7 @@ macro_rules! for_each_known_atom {
             extract: "extract";
             bvnot: "bvnot";
             bvor: "bvor";
+            bvnor: "bvnor";
             bvand: "bvand";
             bvnand: "bvnand";
             bvxor: "bvxor";
@@ -89,6 +90,10 @@ macro_rules! for_each_known_atom {
             bvsge: "bvsge";
             bvsgt: "bvsgt";
             bvcomp: "bvcomp";
+            rotate_left: "rotate_left";
+            rotate_right: "rotate_right";
+            zero_extend: "zero_extend";
+            sign_extend: "sign_extend";
         }
     };
 }

--- a/tests/bit_vectors.rs
+++ b/tests/bit_vectors.rs
@@ -1,0 +1,87 @@
+use easy_smt::{ContextBuilder, Response};
+
+#[test]
+fn test_bv_rotate_identity_z3() {
+    let mut ctx = ContextBuilder::new()
+        .with_z3_defaults()
+        .build()
+        .unwrap();
+
+    let bv = ctx.declare_const("x", ctx.bit_vec_sort(ctx.numeral(32))).unwrap();
+    let rot_left = ctx.rotate_left(4, bv);
+    let rot_right = ctx.rotate_right(4, rot_left);
+    ctx.assert(ctx.eq(bv, rot_right)).unwrap();
+    assert_eq!(ctx.check().unwrap(), Response::Sat);
+}
+
+#[test]
+fn test_bv_rotate_identity_cvc5() {
+    let mut ctx = ContextBuilder::new()
+        .with_cvc5_defaults()
+        .build()
+        .unwrap();
+
+    let bv = ctx.declare_const("x", ctx.bit_vec_sort(ctx.numeral(32))).unwrap();
+    let rot_left = ctx.rotate_left(4, bv);
+    let rot_right = ctx.rotate_right(4, rot_left);
+    ctx.assert(ctx.eq(bv, rot_right)).unwrap();
+    assert_eq!(ctx.check().unwrap(), Response::Sat);
+}
+
+#[test]
+fn test_bv_zero_extend_z3() {
+    let mut ctx = ContextBuilder::new()
+        .with_z3_defaults()
+        .build()
+        .unwrap();
+
+    let bv = ctx.declare_const("x", ctx.bit_vec_sort(ctx.numeral(8))).unwrap();
+    ctx.assert(ctx.eq(bv, ctx.binary(8, 0xFF))).unwrap();
+    // Extend *by* 8 bits, making the input 16 bits total
+    let ext = ctx.zero_extend(8, bv);
+    let expected = ctx.binary(16, 0x00FF);
+    ctx.assert(ctx.eq(ext, expected)).unwrap();
+    assert_eq!(ctx.check().unwrap(), Response::Sat);
+}
+
+#[test]
+fn test_bv_zero_extend_cvc5() {
+    let mut ctx = ContextBuilder::new()
+        .with_cvc5_defaults()
+        .build()
+        .unwrap();
+
+    let bv = ctx.declare_const("x", ctx.bit_vec_sort(ctx.numeral(8))).unwrap();
+    ctx.assert(ctx.eq(bv, ctx.binary(8, 0xFF))).unwrap();
+    // Extend *by* 8 bits, making the input 16 bits total
+    let ext = ctx.zero_extend(8, bv);
+    let expected = ctx.binary(16, 0x00FF);
+    ctx.assert(ctx.eq(ext, expected)).unwrap();
+    assert_eq!(ctx.check().unwrap(), Response::Sat);
+}
+
+#[test]
+fn test_bv_nor_z3() {
+    let mut ctx = ContextBuilder::new()
+        .with_z3_defaults()
+        .build()
+        .unwrap();
+
+    let bv = ctx.declare_const("x", ctx.bit_vec_sort(ctx.numeral(8))).unwrap();
+    let nor_bv = ctx.bvnor(bv, bv);
+    ctx.assert(ctx.eq(bv, nor_bv)).unwrap();
+    assert_eq!(ctx.check().unwrap(), Response::Unsat);
+}
+
+#[test]
+fn test_bv_nor_cvc5() {
+    let mut ctx = ContextBuilder::new()
+        .with_cvc5_defaults()
+        .build()
+        .unwrap();
+
+    let bv = ctx.declare_const("x", ctx.bit_vec_sort(ctx.numeral(8))).unwrap();
+    let nor_bv = ctx.bvnor(bv, bv);
+    ctx.assert(ctx.eq(bv, nor_bv)).unwrap();
+    assert_eq!(ctx.check().unwrap(), Response::Unsat);
+}


### PR DESCRIPTION
This change includes `zero_extend`, `sign_extend`, `rotate_left`, and `rotate_right`.  These seem to be non-standard (i.e., are not in SMTLib2), but are widely supported in solvers.